### PR TITLE
Ensure tests manually tear down props

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,4 +32,4 @@ jobs:
 
             -   uses: "ramsey/composer-install@v1"
 
-            -   run: vendor/bin/phpunit ${{ matrix.path }}
+            -   run: vendor/bin/phpunit --testdox ${{ matrix.path }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,4 +32,4 @@ jobs:
 
             -   uses: "ramsey/composer-install@v1"
 
-            -   run: vendor/bin/phpunit --testdox ${{ matrix.path }}
+            -   run: vendor/bin/phpunit ${{ matrix.path }}

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -144,4 +144,16 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
         return $file->getFileContent();
     }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->applicationFileProcessor,
+            $this->parameterProvider,
+            $this->dynamicSourceLocatorProvider,
+            $this->removedAndAddedFilesCollector,
+            $this->originalTempFileInfo,
+        );
+        gc_collect_cycles();
+    }
 }

--- a/rules-tests/TypeDeclaration/TypeNormalizerTest.php
+++ b/rules-tests/TypeDeclaration/TypeNormalizerTest.php
@@ -48,4 +48,9 @@ final class TypeNormalizerTest extends AbstractTestCase
         $evenMoreNestedArrayType = new ArrayType(new MixedType(), $moreNestedArrayType);
         yield [$evenMoreNestedArrayType, 'int[][][]|string[][][]'];
     }
+
+    protected function tearDown(): void
+    {
+        unset($this->typeNormalizer);
+    }
 }


### PR DESCRIPTION
This can help on picky platforms where PHP's garbage collector and PHPunit don't place as nicely together.
The changes here are tested and allow for the Windows based GitHub workers to complete the testing now.

See a complete but failing workflow here: https://github.com/rectorphp/rector-src/runs/2746052520?check_suite_focus=true